### PR TITLE
Add support for default metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,30 @@
-# ktor-prometheus-feature
-
-# Example of installation and configuration
-
-
 # ktor-promethues - Prometheus request logging for all requests
 [![license](https://img.shields.io/github/license/zensum/ktor-prometheus-feature.svg)]() [![](https://jitpack.io/v/zensum/ktor-prometheus-feature.svg)](https://jitpack.io/#zensum/ktor-promethues-feature)
 
-Ktor-prometheus adds support for request logging with prometheus
-in [ktor](https://ktor.io). Set a promethues Counter for the total amount of requests, including method and response code and a Summary
-to count the total excecution times of the requests.
-
-When setting up the feature, a Prometheus Summary and Counter must be set. If these are not set, there is no point in
-using this feature as it wont do anything.
+Ktor-prometheus adds support for request logging with prometheus in [ktor](https://ktor.io).
 
 ```kotlin
 import se.zensum.ktorPrometheusFeature
 
-// In the implementaion of the Counter, it writes labels in the order of {"HTTP_METHOD", "HTTP_RESPONSE_CODE"} and expects these label names to exists.
-val totalRequests = Counter.build().name("http_total_requests").labelNames("method", "response_code").help("Total number of requests").register()
+embeddedServer(Netty, 8080) {
+    install(PrometheusFeature)
+}.start(wait = true)
+```
+
+Just install the function and two metrics are added `http_request`,
+containing two labels one for the HTTP method and one for the status
+code, and `http_duration_seconds` tracking the processing time of each
+request.
+
+
+If you want to use other names for the metrics feel it is simply a
+matter passing them along in the configuration
+
+```kotlin import
+se.zensum.ktorPrometheusFeature
+
+// We write the method and status code, in that order into the labels and those must therefore exist.
+val totalRequests = Counter.build().name("http_total_requests").labelNames("method", "status_code").help("Total number of requests").register()
 val totalTimer = Summary.build().name("http_total_timer").help("Total response time").register()
 
 embeddedServer(Netty, 8080) {


### PR DESCRIPTION
It makes the library quite a bit easier to use when you just install it. That also enabled removing a few nullity checks. I tried removing the `context.end()` thing does it do anything that context.proceed doesn't?
